### PR TITLE
Refactor ProposalTokenEngine to reuse distributed execution

### DIFF
--- a/src/VertexBPMN.Engine/Execution/ProposalTokenEngine.cs
+++ b/src/VertexBPMN.Engine/Execution/ProposalTokenEngine.cs
@@ -1,39 +1,26 @@
-using System.Collections.Concurrent;
-using Jint;
 using Microsoft.Extensions.Logging;
-using VertexBPMN.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Trace;
+using VertexBPMN.Application;
 using VertexBPMN.Domain.Entities.Modeling;
-using VertexBPMN.Domain.Exceptions;
 using VertexBPMN.Domain.Interfaces;
-using VertexBPMN.Infrastructure.Scripting;
+using VertexBPMN.Engine.Parsing;
+using VertexBPMN.Infrastructure.Persistence.InMemory;
 
 namespace VertexBPMN.Engine.Execution;
 
 /// <summary>
 /// ProposalTokenEngine
-/// Lightweight, purely local in-process engine implementing IProcessEngine.
-/// Intended for development, unit tests, single-node demos.
-/// - No worker registry / distribution
-/// - No messaging layer
-/// - Optional DMN evaluation if parsers provided
-/// - In-memory model registry (BPMN/DMN/CMMN)
-/// - Deterministic synchronous execution loop with async facade
+/// Facade that configures a <see cref="DistributedProcessEngine"/> with in-memory defaults
+/// to provide a lightweight, offline-friendly process engine without duplicating execution logic.
 /// </summary>
-public class ProposalTokenEngine : IProcessEngine
+public sealed class ProposalTokenEngine : IProcessEngine, IDisposable
 {
     private readonly ILogger<ProposalTokenEngine> _logger;
-    private readonly IServiceTaskRegistry _serviceTaskRegistry;
-    private readonly IDmnParser? _dmnParser;
-    private readonly IDmnEngine? _dmnEngine;
-    private readonly IBpmnParser? _bpmnParser;
-    private readonly ICmmnParser? _cmmnParser;
-
-    // In-memory registries (thread-safe)
-    private readonly ConcurrentDictionary<string,string> _bpmnModels = new();
-    private readonly ConcurrentDictionary<string,string> _cmmnModels = new();
-    private readonly ConcurrentDictionary<string,string> _dmnModels  = new();
-
-    private readonly Jint.Engine _scriptEngine = new(); // optional re-use for simple condition evaluations
+    private readonly DistributedProcessEngine _distributedEngine;
+    private readonly IMessageDispatcher _messageDispatcher;
+    private readonly IProcessInstanceStore _processInstanceStore;
+    private bool _disposed;
 
     public ProposalTokenEngine(
         ILogger<ProposalTokenEngine> logger,
@@ -41,308 +28,101 @@ public class ProposalTokenEngine : IProcessEngine
         IBpmnParser? bpmnParser = null,
         IDmnParser? dmnParser = null,
         IDmnEngine? dmnEngine = null,
-        ICmmnParser? cmmnParser = null)
+        ICmmnParser? cmmnParser = null,
+        IAiDecisionService? aiDecisionService = null,
+        IMessageDispatcher? messageDispatcher = null,
+        IProcessInstanceStore? processInstanceStore = null,
+        TracerProvider? tracerProvider = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _serviceTaskRegistry = serviceTaskRegistry ?? throw new ArgumentNullException(nameof(serviceTaskRegistry));
-        _bpmnParser = bpmnParser;
-        _dmnParser = dmnParser;
-        _dmnEngine = dmnEngine;
-        _cmmnParser = cmmnParser;
+        ArgumentNullException.ThrowIfNull(serviceTaskRegistry);
+
+        var tracer = tracerProvider ?? TracerProvider.Default;
+        var baseLogger = (ILogger)logger;
+
+        var resolvedBpmnParser = bpmnParser ?? new BpmnParser(new ForwardingLogger<BpmnParser>(baseLogger), tracer);
+        var resolvedDmnParser = dmnParser ?? new DmnParser(new ForwardingLogger<DmnParser>(baseLogger));
+        var resolvedDmnEngine = dmnEngine ?? new DmnEngine(new ForwardingLogger<DmnEngine>(baseLogger));
+        var resolvedCmmnParser = cmmnParser ?? new CmmnParser();
+        var resolvedAiDecisionService = aiDecisionService ?? new FakeAiDecisionService();
+
+        _messageDispatcher = messageDispatcher ?? new InMemoryMessageDispatcher(serviceTaskRegistry);
+        _processInstanceStore = processInstanceStore ?? new InMemoryProcessInstanceStore();
+
+        _distributedEngine = new DistributedProcessEngine(
+            new ForwardingLogger<DistributedProcessEngine>(baseLogger),
+            serviceTaskRegistry,
+            _messageDispatcher,
+            _processInstanceStore,
+            resolvedDmnEngine,
+            resolvedDmnParser,
+            resolvedCmmnParser,
+            resolvedBpmnParser,
+            resolvedAiDecisionService,
+            tracer);
+
+        _logger.LogInformation("ProposalTokenEngine initialized using DistributedProcessEngine facade");
     }
 
-    #region IProcessEngine Core
-    public async Task<List<string>> ExecuteAsync(BpmnModel model, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return await Task.Run(() => ExecuteInternal(model, cancellationToken), cancellationToken);
-    }
+    public Task<List<string>> ExecuteAsync(BpmnModel model, CancellationToken cancellationToken = default)
+        => _distributedEngine.ExecuteAsync(model, cancellationToken);
 
-    public List<string> Execute(BpmnModel model) => ExecuteInternal(model, CancellationToken.None);
+    public List<string> Execute(BpmnModel model)
+        => _distributedEngine.Execute(model);
 
     public Task<List<string>> ExecuteCaseAsync(CaseModel model, CancellationToken cancellationToken = default)
-    {
-        // Minimal placeholder – no full CMMN state machine here
-        var trace = new List<string>
-        {
-            "CaseExecutionLocalMode: Simplified",
-            "Note: Full CMMN behavior requires distributed engine"
-        };
-        // Trigger plan items without entry sentries in a simple sequential fashion
-        foreach (var plan in model.PlanItems.Where(p => p.EntrySentryRefs == null || p.EntrySentryRefs.Count == 0))
-        {
-            trace.Add($"PlanItemStarted: {plan.Id} ({plan.Type})");
-            trace.Add($"PlanItemCompleted: {plan.Id}");
-        }
-        return Task.FromResult(trace);
-    }
+        => _distributedEngine.ExecuteCaseAsync(model, cancellationToken);
 
-    public async Task<List<string>> ExecuteProcessAsync(string processId, CancellationToken cancellationToken = default)
-    {
-        if (!_bpmnModels.TryGetValue(processId, out var xml))
-            throw new DistributedTokenException($"BPMN model '{processId}' not registered");
-        if (_bpmnParser == null)
-            throw new DistributedTokenException("No BPMN parser provided to ProposalTokenEngine");
-        var model = await _bpmnParser.ParseAsync(xml, cancellationToken);
-        return await ExecuteAsync(model, cancellationToken);
-    }
+    public Task<List<string>> ExecuteProcessAsync(string processId, CancellationToken cancellationToken = default)
+        => _distributedEngine.ExecuteProcessAsync(processId, cancellationToken);
 
     public Task<bool> CanExecuteAsync(string nodeId, CancellationToken cancellationToken = default)
-        => Task.FromResult(true); // Always true in local mode
-    #endregion
+        => _distributedEngine.CanExecuteAsync(nodeId, cancellationToken);
 
-    #region Model Registration & Retrieval
     public Task RegisterBpmnModelAsync(string processId, string bpmnXml, CancellationToken cancellationToken = default)
-    {
-        _bpmnModels[processId] = bpmnXml;
-        _logger.LogInformation("BPMN model registered (local) {ProcessId}", processId);
-        return Task.CompletedTask;
-    }
+        => _distributedEngine.RegisterBpmnModelAsync(processId, bpmnXml, cancellationToken);
 
     public Task RegisterCmmnModelAsync(string caseId, string cmmnXml)
-    {
-        _cmmnModels[caseId] = cmmnXml;
-        _logger.LogInformation("CMMN model registered (local) {CaseId}", caseId);
-        return Task.CompletedTask;
-    }
+        => _distributedEngine.RegisterCmmnModelAsync(caseId, cmmnXml);
 
-    public async Task RegisterDmnModelAsync(string decisionId, string dmnXml)
-    {
-        // Parse once for validation if parser available
-        if (_dmnParser != null)
-        {
-            try { await _dmnParser.ParseAsync(dmnXml); }
-            catch (Exception ex) { throw new DistributedTokenException($"Invalid DMN XML for {decisionId}", ex); }
-        }
-        _dmnModels[decisionId] = dmnXml;
-        _logger.LogInformation("DMN model registered (local) {DecisionId}", decisionId);
-    }
+    public Task RegisterDmnModelAsync(string decisionId, string dmnXml)
+        => _distributedEngine.RegisterDmnModelAsync(decisionId, dmnXml);
 
-    public async Task<CaseModel> GetCmmnModelAsync(string caseId)
-    {
-        if (!_cmmnModels.TryGetValue(caseId, out var xml))
-            throw new DistributedTokenException($"CMMN model '{caseId}' not registered");
-        if (_cmmnParser == null)
-            throw new DistributedTokenException("No CMMN parser provided to ProposalTokenEngine");
-        return await _cmmnParser.ParseAsync(xml);
-    }
+    public Task<CaseModel> GetCmmnModelAsync(string caseId)
+        => _distributedEngine.GetCmmnModelAsync(caseId);
 
     public Task<List<HistoricalCaseData>> GetHistoricalCaseDataAsync(string caseId)
+        => _distributedEngine.GetHistoricalCaseDataAsync(caseId);
+
+    public void Dispose()
     {
-        // Local engine has no persistence – return empty
-        return Task.FromResult(new List<HistoricalCaseData>());
-    }
-    #endregion
-
-    #region BPMN Execution (Simplified)
-    private List<string> ExecuteInternal(BpmnModel model, CancellationToken ct)
-    {
-        var trace=new List<string>();
-        var start=model.Events.FirstOrDefault(e=>e.Type=="startEvent")??throw new BpmnEngineException("No startEvent found");
-        trace.Add($"StartEvent: {start.Id}");
-
-        // Worklist (queue) for breadth-first style token processing
-        var q=new Queue<ExecutionToken>();
-        q.Enqueue(new ExecutionToken(Guid.NewGuid(),Guid.NewGuid(),start.Id,start.Type,new(model.ProcessVariables??new()),DateTime.UtcNow));
-
-        int guard=0; const int max=2000;
-        while(q.Count>0 && guard<max && !ct.IsCancellationRequested)
+        if (_disposed)
         {
-            guard++;
-            var token=q.Dequeue();
-            var node=FindNode(model, token.CurrentNodeId);
-            if(node==null)
-            {
-                trace.Add($"NodeNotFound: {token.CurrentNodeId}");
-                continue;
-            }
-            switch(node)
-            {
-                case BpmnEvent evt: HandleEvent(evt,token,model,trace,q); break;
-                case BpmnTask task: HandleTask(task,token,model,trace,q).GetAwaiter().GetResult(); break;
-                case BpmnGateway gw: HandleGateway(gw,token,model,trace,q); break;
-                case BpmnSubprocess sp: HandleSubprocess(sp,token,model,trace,q); break;
-            }
-        }
-
-        if(guard>=max) trace.Add("ExecutionLimitReached");
-
-        return trace;
-    }
-
-    private object? FindNode(BpmnModel model,string id)
-    {
-        var evt=model.Events.FirstOrDefault(e=>e.Id==id); if(evt!=null) return evt;
-        var task=model.Tasks.FirstOrDefault(t=>t.Id==id); if(task!=null) return task;
-        var gw=model.Gateways.FirstOrDefault(g=>g.Id==id); if(gw!=null) return gw;
-        return model.Subprocesses.FirstOrDefault(s=>s.Id==id);
-    }
-
-    private void EnqueueNext(string currentId,ExecutionToken token,BpmnModel model,Queue<ExecutionToken> q,List<string> trace)
-    {
-        foreach(var f in model.SequenceFlows.Where(f=>f.SourceRef==currentId)) {
-            trace.Add($"SequenceFlow: {f.Id}");
-            q.Enqueue(token with { CurrentNodeId=f.TargetRef, NodeType=GetNodeType(model,f.TargetRef)});
-        }
-    }
-
-    private string GetNodeType(BpmnModel model,string nodeId)
-    {
-        if(model.Events.Any(e=>e.Id==nodeId)) return model.Events.First(e=>e.Id==nodeId).Type;
-        if(model.Tasks.Any(t=>t.Id==nodeId)) return model.Tasks.First(t=>t.Id==nodeId).Type;
-        if(model.Gateways.Any(g=>g.Id==nodeId)) return model.Gateways.First(g=>g.Id==nodeId).Type;
-        if(model.Subprocesses.Any(s=>s.Id==nodeId)) return "subprocess";
-        return "unknown";
-    }
-
-    private void HandleEvent(BpmnEvent evt,ExecutionToken token,BpmnModel model,List<string> trace,Queue<ExecutionToken> q)
-    {
-        switch(evt.Type)
-        {
-            case "startEvent":
-                trace.Add($"StartPassed: {evt.Id}");
-                EnqueueNext(evt.Id,token,model,q,trace);
-                break;
-            case "endEvent":
-                trace.Add($"EndEvent: {evt.Id}");
-                break;
-            default:
-                trace.Add($"Event: {evt.Type} {evt.Id}");
-                EnqueueNext(evt.Id,token,model,q,trace);
-                break;
-        }
-    }
-
-    private async Task HandleTask(BpmnTask task,ExecutionToken token,BpmnModel model,List<string> trace,Queue<ExecutionToken> q)
-    {
-        switch(task.Type.ToLowerInvariant())
-        {
-            case "scripttask":
-                if(model.ProcessVariables!=null) foreach(var kv in model.ProcessVariables) token.Variables[kv.Key]=kv.Value;
-                await ScriptTaskExecution.TryHandleScriptTaskAsync(task, token.Variables, CancellationToken.None);
-                model.ProcessVariables ??= new();
-                foreach(var kv in token.Variables) model.ProcessVariables[kv.Key]=kv.Value;
-                trace.Add($"ScriptTaskCompleted: {task.Id}");
-                break;
-            case "servicetask":
-                await HandleServiceTaskAsync(task,token,model,trace);
-                break;
-            case "businessruletask":
-                await HandleBusinessRuleTaskAsync(task,token,model,trace);
-                break;
-            case "usertask":
-                trace.Add($"UserTask(parked): {task.Id}");
-                // local mode: do not auto-complete user tasks
-                return; // stop propagation
-            default:
-                trace.Add($"Task: {task.Type} {task.Id}");
-                break;
-        }
-        EnqueueNext(task.Id,token,model,q,trace);
-    }
-
-    private async Task HandleServiceTaskAsync(BpmnTask task,ExecutionToken token,BpmnModel model,List<string> trace)
-    {
-        var impl=task.Implementation ?? task.Attributes?.GetValueOrDefault("implementation");
-        if(string.IsNullOrWhiteSpace(impl))
-        {
-            trace.Add($"ServiceTaskNoImplementation: {task.Id}");
             return;
         }
-        if(_serviceTaskRegistry.TryResolve(impl,out var handler))
-        {
-            await handler.ExecuteAsync(task.Attributes??new(), token.Variables, CancellationToken.None);
-            trace.Add($"ServiceTaskCompleted: {task.Id}");
-        }
-        else
-        {
-            trace.Add($"ServiceTaskHandlerNotFound: {impl}");
-        }
-        model.ProcessVariables ??= new();
-        foreach(var kv in token.Variables) model.ProcessVariables[kv.Key]=kv.Value;
+
+        _distributedEngine.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
     }
 
-    private async Task HandleBusinessRuleTaskAsync(BpmnTask task,ExecutionToken token,BpmnModel model,List<string> trace)
+    private sealed class ForwardingLogger<T> : ILogger<T>
     {
-        var attrs=task.Attributes??new Dictionary<string,string>();
-        if(!attrs.TryGetValue("camunda:decisionRef",out var decisionRef)&&
-           !attrs.TryGetValue("flowable:decisionRef",out decisionRef))
-        {
-            trace.Add($"BusinessRuleTaskNoDecision: {task.Id}");
-            return;
-        }
-        var resultVar= attrs.GetValueOrDefault("camunda:resultVariable")
-                      ?? attrs.GetValueOrDefault("flowable:resultVariable")
-                      ?? "decisionResult";
-        if(!_dmnModels.TryGetValue(decisionRef,out var dmnXml) || _dmnParser==null || _dmnEngine==null)
-        {
-            trace.Add($"BusinessRuleLocalFallback: {task.Id} decisionRef={decisionRef} unavailable");
-            token.Variables[resultVar]="unavailable";
-            return;
-        }
-        try
-        {
-            var decision= await _dmnParser.ParseAsync(dmnXml, CancellationToken.None);
-            var eval= await _dmnEngine.EvaluateDecisionAsync(decision, token.Variables);
-            token.Variables[resultVar]=eval;
-            model.ProcessVariables ??= new();
-            model.ProcessVariables[resultVar]=eval;
-            trace.Add($"BusinessRuleEvaluated: {task.Id}->{resultVar}");
-        }
-        catch(Exception ex)
-        {
-            trace.Add($"BusinessRuleError: {task.Id} {ex.Message}");
-            _logger.LogError(ex, "DMN evaluation failed for task {TaskId}", task.Id);
-        }
-    }
+        private readonly ILogger _inner;
 
-    private void HandleGateway(BpmnGateway gw,ExecutionToken token,BpmnModel model,List<string> trace,Queue<ExecutionToken> q)
-    {
-        var flows=model.SequenceFlows.Where(f=>f.SourceRef==gw.Id).ToList();
-        switch(gw.Type)
+        public ForwardingLogger(ILogger inner)
         {
-            case "parallelGateway":
-                trace.Add($"ParallelGateway: {gw.Id}");
-                foreach(var f in flows)
-                {
-                    trace.Add($"ParallelBranch: {f.TargetRef}");
-                    q.Enqueue(token with { CurrentNodeId=f.TargetRef, NodeType=GetNodeType(model,f.TargetRef)});
-                }
-                break;
-            case "exclusiveGateway":
-                var first=flows.FirstOrDefault();
-                if(first!=null)
-                {
-                    trace.Add($"ExclusiveSelected: {first.TargetRef}");
-                    q.Enqueue(token with { CurrentNodeId=first.TargetRef, NodeType=GetNodeType(model,first.TargetRef)});
-                }
-                break;
-            case "inclusiveGateway":
-                trace.Add($"InclusiveGateway: {gw.Id}");
-                foreach(var f in flows)
-                {
-                    trace.Add($"InclusiveBranch: {f.TargetRef}");
-                    q.Enqueue(token with { CurrentNodeId=f.TargetRef, NodeType=GetNodeType(model,f.TargetRef)});
-                }
-                break;
-            default:
-                trace.Add($"GatewayUnsupported: {gw.Type} {gw.Id}");
-                break;
+            _inner = inner ?? NullLogger.Instance;
         }
-    }
 
-    private void HandleSubprocess(BpmnSubprocess sp,ExecutionToken token,BpmnModel model,List<string> trace,Queue<ExecutionToken> q)
-    {
-        trace.Add($"Subprocess: {sp.Id}");
-        if(sp.IsMultiInstance)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
         {
-            var count= sp.LoopCardinality ?? 1;
-            for(int i=0;i<count;i++)
-            {
-                trace.Add($"MultiInstanceSubprocessInstance: {sp.Id}#{i+1}");
-            }
+            _inner.Log(logLevel, eventId, state, exception, formatter);
         }
-        EnqueueNext(sp.Id,token,model,q,trace);
     }
-    #endregion
 }

--- a/src/VertexBPMN.Engine/Parsing/CmmnParser.cs
+++ b/src/VertexBPMN.Engine/Parsing/CmmnParser.cs
@@ -19,15 +19,28 @@ public class CmmnParser : ICmmnParser
             var caseId = caseElement.Attribute("id")?.Value ?? throw new CmmnParseException("Case ID missing");
             var caseName = caseElement.Attribute("name")?.Value ?? caseId;
 
-            var planItems = caseElement.Descendants(ns + "planItem").Select(item => new PlanItem(
-                item.Attribute("id")?.Value ?? "",
-                item.Element(ns + "definitionRef")?.Name.LocalName ?? "",
-                item.Attribute("definitionRef")?.Value ?? "",
-                item.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value),
-                item.Descendants(ns + "entryCriterion").Select(c => c.Attribute("sentryRef")?.Value ?? "").ToList(),
-                item.Descendants(ns + "exitCriterion").Select(c => c.Attribute("sentryRef")?.Value ?? "").ToList(),
-                item.Attribute("isDiscretionary")?.Value == "true"
-            )).ToList();
+            var planItems = caseElement
+                .Descendants(ns + "planItem")
+                .Select(item =>
+                {
+                    var type = item.Attribute("definitionType")?.Value
+                               ?? item.Element(ns + "definitionRef")?.Attribute("type")?.Value
+                               ?? item.Element(ns + "definitionRef")?.Value
+                               ?? item.Element(ns + "definitionRef")?.Name.LocalName
+                               ?? item.Attribute("type")?.Value
+                               ?? string.Empty;
+
+                    return new PlanItem(
+                        item.Attribute("id")?.Value ?? string.Empty,
+                        type,
+                        item.Attribute("definitionRef")?.Value ?? string.Empty,
+                        item.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value),
+                        item.Descendants(ns + "entryCriterion").Select(c => c.Attribute("sentryRef")?.Value ?? "").ToList(),
+                        item.Descendants(ns + "exitCriterion").Select(c => c.Attribute("sentryRef")?.Value ?? "").ToList(),
+                        item.Attribute("isDiscretionary")?.Value == "true"
+                    );
+                })
+                .ToList();
 
             var sentries = caseElement.Descendants(ns + "sentry").Select(sentry => new Sentry(
                 sentry.Attribute("id")?.Value ?? "",

--- a/src/VertexBPMN.Infrastructure/Persistence/InMemory/InMemoryMessageDispatcher.cs
+++ b/src/VertexBPMN.Infrastructure/Persistence/InMemory/InMemoryMessageDispatcher.cs
@@ -25,7 +25,6 @@ public class InMemoryMessageDispatcher : IMessageDispatcher
     private readonly ConcurrentBag<CaseToken> _caseTokens = new();
     private readonly ConcurrentBag<(string TaskId, string TaskType, Dictionary<string, object> Variables)> _queuedTasks = new();
     private readonly ConcurrentBag<CaseFileUpdateEvent> _caseFileUpdates = new();
-    private IMessageDispatcher _messageDispatcherImplementation;
 
     public InMemoryMessageDispatcher(IServiceTaskRegistry registry)
     {
@@ -116,9 +115,7 @@ public class InMemoryMessageDispatcher : IMessageDispatcher
 
     public Task DispatchAiTaskAsync(string targetWorkerId, string aiProvider, string aiModel, Dictionary<string, string> attributes,
         Dictionary<string, object> variables, CancellationToken cancellationToken = default)
-    {
-        return _messageDispatcherImplementation.DispatchAiTaskAsync(targetWorkerId, aiProvider, aiModel, attributes, variables, cancellationToken);
-    }
+        => Task.CompletedTask;
 
     // ---------- Helpers / Safe Invocation ----------
 

--- a/src/VertexBPMN.Infrastructure/Persistence/InMemory/InMemoryProcessInstanceStore.cs
+++ b/src/VertexBPMN.Infrastructure/Persistence/InMemory/InMemoryProcessInstanceStore.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Text.Json;
+using System.Xml.Linq;
 using VertexBPMN.Domain.Entities;
 using VertexBPMN.Domain.Entities.Modeling;
 using VertexBPMN.Domain.Interfaces;
@@ -21,6 +23,7 @@ public sealed class InMemoryProcessInstanceStore : IProcessInstanceStore
     private readonly ConcurrentDictionary<string, WorkerNode> _workers = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _dmnModels = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _cmmnModels = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<HistoricalCaseData>> _historicalCaseData = new(StringComparer.Ordinal);
     private readonly ConcurrentQueue<DeadLetterEntry> _deadLetters = new();
 
     private record DeadLetterEntry(DateTime TimestampUtc, string TokenType, string SerializedToken, string ErrorMessage);
@@ -184,20 +187,150 @@ public sealed class InMemoryProcessInstanceStore : IProcessInstanceStore
 
     public Task UpdateCaseModelAsync(CaseModel model)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(model);
+        var serialized = SerializeCaseModel(model);
+        _cmmnModels[model.Id] = serialized;
+        return Task.CompletedTask;
     }
 
     public Task SaveHistoricalCaseDataAsync(HistoricalCaseData data)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(data);
+        var queue = _historicalCaseData.GetOrAdd(data.CaseId, _ => new ConcurrentQueue<HistoricalCaseData>());
+        queue.Enqueue(CloneHistoricalCaseData(data));
+        return Task.CompletedTask;
     }
 
     public Task<List<HistoricalCaseData>> GetHistoricalCaseDataAsync(string caseId)
     {
-        throw new NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(caseId);
+        if (_historicalCaseData.TryGetValue(caseId, out var queue))
+        {
+            var snapshot = queue.ToArray().Select(CloneHistoricalCaseData).ToList();
+            return Task.FromResult(snapshot);
+        }
+
+        return Task.FromResult(new List<HistoricalCaseData>());
     }
 
     // Helper methods (reflection-safe to cope with incomplete domain model definitions provided)
+
+    private static HistoricalCaseData CloneHistoricalCaseData(HistoricalCaseData data)
+    {
+        var caseFile = data.CaseFile != null
+            ? new Dictionary<string, object>(data.CaseFile)
+            : new Dictionary<string, object>();
+        var completedPlanItems = data.CompletedPlanItems != null
+            ? new List<string>(data.CompletedPlanItems)
+            : new List<string>();
+
+        return new HistoricalCaseData(data.CaseId, caseFile, completedPlanItems, data.Timestamp);
+    }
+
+    private static string SerializeCaseModel(CaseModel model)
+    {
+        var ns = XNamespace.Get("https://www.omg.org/spec/CMMN/20151109/MODEL");
+
+        var caseElement = new XElement(ns + "case",
+            new XAttribute("id", model.Id ?? string.Empty),
+            new XAttribute("name", model.Name ?? string.Empty));
+
+        if (model.Attributes != null)
+        {
+            foreach (var attribute in model.Attributes)
+            {
+                if (!string.IsNullOrWhiteSpace(attribute.Key) && attribute.Value is not null)
+                    caseElement.SetAttributeValue(attribute.Key, attribute.Value);
+            }
+        }
+
+        foreach (var planItem in model.PlanItems ?? new List<PlanItem>())
+        {
+            var planItemElement = new XElement(ns + "planItem",
+                new XAttribute("id", planItem.Id ?? string.Empty));
+
+            if (!string.IsNullOrWhiteSpace(planItem.DefinitionRef))
+                planItemElement.SetAttributeValue("definitionRef", planItem.DefinitionRef);
+
+            if (!string.IsNullOrWhiteSpace(planItem.Type))
+                planItemElement.SetAttributeValue("definitionType", planItem.Type);
+
+            if (planItem.IsDiscretionary)
+                planItemElement.SetAttributeValue("isDiscretionary", "true");
+
+            if (planItem.Attributes != null)
+            {
+                foreach (var attribute in planItem.Attributes)
+                {
+                    if (!string.IsNullOrWhiteSpace(attribute.Key) && attribute.Value is not null)
+                        planItemElement.SetAttributeValue(attribute.Key, attribute.Value);
+                }
+            }
+
+            if (planItem.EntrySentryRefs != null)
+            {
+                foreach (var sentryRef in planItem.EntrySentryRefs.Where(r => !string.IsNullOrWhiteSpace(r)))
+                {
+                    planItemElement.Add(new XElement(ns + "entryCriterion", new XAttribute("sentryRef", sentryRef!)));
+                }
+            }
+
+            if (planItem.ExitSentryRefs != null)
+            {
+                foreach (var sentryRef in planItem.ExitSentryRefs.Where(r => !string.IsNullOrWhiteSpace(r)))
+                {
+                    planItemElement.Add(new XElement(ns + "exitCriterion", new XAttribute("sentryRef", sentryRef!)));
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(planItem.Type))
+            {
+                planItemElement.Add(new XElement(ns + "definitionRef", new XAttribute("type", planItem.Type)));
+            }
+
+            caseElement.Add(planItemElement);
+        }
+
+        foreach (var sentry in model.Sentries ?? new List<Sentry>())
+        {
+            var sentryElement = new XElement(ns + "sentry",
+                new XAttribute("id", sentry.Id ?? string.Empty));
+
+            if (!string.IsNullOrWhiteSpace(sentry.OnPartRef))
+            {
+                sentryElement.Add(new XElement(ns + "onPart", new XAttribute("planItemRef", sentry.OnPartRef)));
+            }
+
+            if (sentry.Conditions != null)
+            {
+                foreach (var condition in sentry.Conditions)
+                {
+                    var conditionElement = new XElement(ns + "condition");
+                    if (!string.IsNullOrWhiteSpace(condition.VariableRef))
+                        conditionElement.SetAttributeValue("variableRef", condition.VariableRef);
+                    if (!string.IsNullOrWhiteSpace(condition.OnPartEvent))
+                        conditionElement.SetAttributeValue("onPartEvent", condition.OnPartEvent);
+                    if (!string.IsNullOrWhiteSpace(condition.LogicalOperator))
+                        conditionElement.SetAttributeValue("logicalOperator", condition.LogicalOperator);
+
+                    conditionElement.Add(new XElement(ns + "expression", condition.Expression ?? string.Empty));
+                    sentryElement.Add(conditionElement);
+                }
+            }
+
+            caseElement.Add(sentryElement);
+        }
+
+        foreach (var caseFileItem in model.CaseFileItems ?? new List<CaseFileItem>())
+        {
+            var caseFileElement = new XElement(ns + "caseFileItem",
+                new XAttribute("id", caseFileItem.Id ?? string.Empty),
+                new XAttribute("name", caseFileItem.Name ?? string.Empty));
+            caseElement.Add(caseFileElement);
+        }
+
+        return new XDocument(caseElement).ToString(SaveOptions.DisableFormatting);
+    }
 
     private static Guid GetTokenId(ExecutionToken token)
     {


### PR DESCRIPTION
## Summary
- wrap the in-process ProposalTokenEngine around DistributedProcessEngine with in-memory defaults and logger forwarding
- make the CMMN parser tolerant of serialized definition type hints so regenerated case models round-trip
- implement in-memory case model updates and historical data persistence alongside a safe no-op AI dispatcher

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c933c0ba44832db510f8844f7754ed