### PR TITLE
fix: preserve vendor namespaces in BPMN roundtrip

### DIFF
--- a/src/VertexBPMN.Engine/Parsing/BpmnParser.cs
+++ b/src/VertexBPMN.Engine/Parsing/BpmnParser.cs
@@ -1103,35 +1103,45 @@ public partial class BpmnParser : IBpmnParser
             }
         }
 
+        string FormatQualifiedName(XElement node, string? prefix)
+        {
+            if (!string.IsNullOrEmpty(prefix)) return $"{prefix}:{node.Name.LocalName}";
+            var namespaceUri = node.Name.Namespace.NamespaceName;
+            return string.IsNullOrEmpty(namespaceUri)
+                ? node.Name.LocalName
+                : $"{{{namespaceUri}}}{node.Name.LocalName}";
+        }
+
+        string FormatQualifiedAttributeName(XAttribute attribute, string? prefix)
+        {
+            if (!string.IsNullOrEmpty(prefix)) return $"{prefix}:{attribute.Name.LocalName}";
+            var namespaceUri = attribute.Name.Namespace.NamespaceName;
+            return string.IsNullOrEmpty(namespaceUri)
+                ? attribute.Name.LocalName
+                : $"{{{namespaceUri}}}{attribute.Name.LocalName}";
+        }
+
         void Harvest(XElement node)
         {
             var elemPrefix = node.GetPrefixOfNamespace(node.Name.Namespace);
-            foreach (var attr in node.Attributes())
+            var elemQName = FormatQualifiedName(node, elemPrefix);
+            var nonNamespaceAttributes = node.Attributes().Where(attr => !attr.IsNamespaceDeclaration).ToList();
+
+            foreach (var attr in nonNamespaceAttributes)
             {
-                // Element qualified name (with prefix if present)           
-                var elemQName = string.IsNullOrEmpty(elemPrefix)
-                    ? node.Name.LocalName
-                    : $"{elemPrefix}:{node.Name.LocalName}";
-
-                // Attribute qualified name (attributes can also be namespaced)
-                string? attrPrefix = null;
-                if (attr.Name.Namespace != XNamespace.None)
-                    attrPrefix = node.GetPrefixOfNamespace(attr.Name.Namespace);
-
-                var attrQName = string.IsNullOrEmpty(attrPrefix)
-                    ? attr.Name.LocalName
-                    : $"{attrPrefix}:{attr.Name.LocalName}";
-
-                var key = $"{elemQName}.{attrQName}";
-                dict[key] = attr.Value;
+                // Attribute qualified name (attributes can also be namespaced).
+                string? attrPrefix = attr.Name.Namespace == XNamespace.None
+                    ? null
+                    : node.GetPrefixOfNamespace(attr.Name.Namespace);
+                var attrQName = FormatQualifiedAttributeName(attr, attrPrefix);
+                dict[$"{elemQName}.{attrQName}"] = attr.Value;
             }
 
-            if (!node.HasAttributes && node != extParent)
+            if (nonNamespaceAttributes.Count == 0 && node != extParent)
             {
-                var key = string.IsNullOrEmpty(elemPrefix)
-                    ? node.Name.LocalName
-                    : $"{elemPrefix}:{node.Name.LocalName}";
-                dict[key] = "true";
+                dict[$"{elemQName}.__present"] = "true";
+                if (!node.HasElements && !string.IsNullOrEmpty(node.Value))
+                    dict[$"{elemQName}.__text"] = node.Value;
             }
 
             foreach (var child in node.Elements()) Harvest(child);

--- a/src/VertexBPMN.Engine/Serialization/BpmnSerializer.cs
+++ b/src/VertexBPMN.Engine/Serialization/BpmnSerializer.cs
@@ -299,6 +299,11 @@ public class BpmnSerializer
                     extRoot.Add(el);
                 }
                 if (attrName == "__present") continue;
+                if (attrName == "__text")
+                {
+                    el.Value = kv.Value;
+                    continue;
+                }
                 el.SetAttributeValue(string.IsNullOrEmpty(attrNsUri) ? XName.Get(attrName) : XName.Get(attrName, attrNsUri), kv.Value);
             }
             if (elementMap.Count > 0) parent.Add(extRoot);

--- a/tests/VertexBPMN.Test.Parsing/Conformance/C.8.1_Test.cs
+++ b/tests/VertexBPMN.Test.Parsing/Conformance/C.8.1_Test.cs
@@ -41,5 +41,22 @@ namespace VertexBPMN.Test.Parsing.Conformance
                     Console.WriteLine($"Result item: {item}");
                 }
         }
+
+        [Fact]
+        public void Test_C_8_1_Bpmn_Roundtrip_Preserves_Boc_Extensions()
+        {
+            var bpmnFile = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "Reference", "C.8.1.bpmn");
+            var xml = File.ReadAllText(bpmnFile);
+            var parser = new BpmnParser();
+            var model = parser.ParseAsync(xml.Replace('\'', '"')).GetAwaiter().GetResult();
+
+            var exported = parser.Serialize(model);
+
+            Assert.False(string.IsNullOrWhiteSpace(exported));
+            const string bocNamespace = "http://www.boc-group.com";
+            Assert.Contains(bocNamespace, exported);
+            var document = System.Xml.Linq.XDocument.Parse(exported);
+            Assert.NotEmpty(document.Descendants(System.Xml.Linq.XName.Get("Description", bocNamespace)));
+        }
     }
 }


### PR DESCRIPTION
## What changed
- Preserve vendor namespace information during BPMN extension extraction so unprefixed BOC elements survive roundtrips correctly.
- Teach the serializer to restore extension text nodes without turning them into invalid attributes.
- Add a regression test for `C.8.1` that exercises the BOC extension roundtrip.

## Why
The parser was treating namespace declarations like regular attributes, which caused vendor extension content to be reconstructed with broken namespace context during export.

## Impact
- BOC/vendor extensions now survive import/export roundtrips.
- The `C.8.1` namespace case is covered by a regression test.
- This removes the invalid XML namespace redefinition that was failing CI.

## Validation
- `dotnet test tests/VertexBPMN.Test.Parsing/VertexBPMN.Test.Parsing.csproj --configuration Release --no-restore -- --filter-class VertexBPMN.Test.Parsing.Conformance.C_8_1_Test`
- `dotnet test tests/VertexBPMN.Test.Parsing/VertexBPMN.Test.Parsing.csproj --configuration Release --no-restore -- --filter-class VertexBPMN.Test.Parsing.Conformance.MIWGTestSuite2025Roundtrip`
- `dotnet test tests/VertexBPMN.Test.Parsing/VertexBPMN.Test.Parsing.csproj --configuration Release --no-restore --verbosity quiet -- --output Normal`
- Full solution run still reports unrelated local failures in the memory profiler benchmark and `StudioUiTestHost` startup, but the parsing assembly is green.